### PR TITLE
Improve Code Quality - 3 of x

### DIFF
--- a/Src/Protsyk.PMS.FullText.Core.UnitTests/HeapTests.cs
+++ b/Src/Protsyk.PMS.FullText.Core.UnitTests/HeapTests.cs
@@ -1,7 +1,6 @@
-﻿using System.Linq;
-
+﻿using System;
+using System.Linq;
 using Protsyk.PMS.FullText.Core.Collections;
-
 using Xunit;
 
 namespace Protsyk.PMS.FullText.Core.UnitTests

--- a/Src/Protsyk.PMS.FullText.Core.UnitTests/Query/OrQueryTest.cs
+++ b/Src/Protsyk.PMS.FullText.Core.UnitTests/Query/OrQueryTest.cs
@@ -40,7 +40,6 @@ namespace Protsyk.PMS.FullText.Core.UnitTests
             }
         }
 
-
         [Fact]
         public void TestOrQueryWithFixedPostingList_3()
         {

--- a/Src/Protsyk.PMS.FullText.Core/Automata/FST.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Automata/FST.cs
@@ -1280,8 +1280,10 @@ namespace Protsyk.PMS.FullText.Core.Automata
             result[4] = (byte)'0';
             result[5] = (byte)'1';
             result[6] = (byte)'S';
-            Array.Copy(BitConverter.GetBytes(names[Initial]), 0, result, 7, sizeof(long));
-            var writeIndex = 7 + sizeof(long);
+
+            int writeIndex = 7;
+            BinaryPrimitives.WriteInt64LittleEndian(result.AsSpan(writeIndex), names[Initial]);
+            writeIndex += sizeof(long);
 
             for (int i = 0; i < states.Count; ++i)
             {

--- a/Src/Protsyk.PMS.FullText.Core/Automata/FST.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Automata/FST.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -883,7 +885,7 @@ namespace Protsyk.PMS.FullText.Core.Automata
 
                 if (stateOffset == initial)
                 {
-                    result.AppendFormat("{0}[label = \"{0}\", shape = circle, style = bold, fontsize = 14]", stateOffset);
+                    result.Append(CultureInfo.InvariantCulture, $"{stateOffset}[label = \"{stateOffset}\", shape = circle, style = bold, fontsize = 14]");
                     result.AppendLine();
                 }
                 else if (isFinal)
@@ -919,22 +921,17 @@ namespace Protsyk.PMS.FullText.Core.Automata
                     }
                 }
 
-                if (result.Length > 65536)
+                if (result.Length > 65_536)
                 {
-                    AppendText(outputStorage, result.ToString());
+                    outputStorage.AppendUtf8Bytes(result.ToString());
                     result.Clear();
                 }
             }
 
             result.AppendLine("}");
-            AppendText(outputStorage, result.ToString());
+            outputStorage.AppendUtf8Bytes(result.ToString());
         }
 
-        private void AppendText(IPersistentStorage outputStorage, string text)
-        {
-            var bytes = Encoding.UTF8.GetBytes(text);
-            outputStorage.WriteAll(outputStorage.Length, bytes, 0, bytes.Length);
-        }
         #endregion
 
         #region IFST
@@ -1795,7 +1792,7 @@ namespace Protsyk.PMS.FullText.Core.Automata
         }
     }
 
-    internal class Utils
+    internal static class Utils
     {
         // Calculate length of the longest common prefix
         public static int LCP(string a, string b)

--- a/Src/Protsyk.PMS.FullText.Core/Automata/FST.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Automata/FST.cs
@@ -460,7 +460,7 @@ namespace Protsyk.PMS.FullText.Core.Automata
             End();
 
             var data = new byte[storage.Length];
-            storage.ReadAll(0, data, 0, data.Length);
+            storage.ReadAll(0, data);
             return FST<T>.FromBytesCompressed(data, outputType);
         }
 
@@ -1785,10 +1785,12 @@ namespace Protsyk.PMS.FullText.Core.Automata
 
         public int WriteTo(string value, byte[] buffer, int startIndex)
         {
-            var bytes = Encoding.UTF8.GetBytes(value);
-            var size = VarInt.WriteVInt32(bytes.Length, buffer, startIndex);
-            Array.Copy(bytes, 0, buffer, startIndex + size, bytes.Length);
-            return size + bytes.Length;
+            int byteCount = Encoding.UTF8.GetByteCount(value);
+            var size = VarInt.WriteVInt32(byteCount, buffer, startIndex);
+
+            Encoding.UTF8.GetBytes(value, buffer.AsSpan(startIndex + size));
+
+            return size + byteCount;
         }
     }
 

--- a/Src/Protsyk.PMS.FullText.Core/Automata/Levenshtein/AutomatonLevenshtein.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Automata/Levenshtein/AutomatonLevenshtein.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 namespace Protsyk.PMS.FullText.Core.Automata
 {

--- a/Src/Protsyk.PMS.FullText.Core/Automata/Levenshtein/LevenshteinMatcher.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Automata/Levenshtein/LevenshteinMatcher.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Protsyk.PMS.FullText.Core.Automata
+﻿namespace Protsyk.PMS.FullText.Core.Automata
 {
     /// <summary>
     /// Match all elements in the Trie within given Levenshtein distance

--- a/Src/Protsyk.PMS.FullText.Core/Collections/Btree.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/Btree.cs
@@ -501,7 +501,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
                 text.Append(node.Keys[i]);
                 text.Append(" - ");
                 text.Append(node.Values[i]);
-                text.Append("|");
+                text.Append('|');
             }
             text.AppendFormat("<f{0}>", node.Keys.Count);
             text.Append("\"];");

--- a/Src/Protsyk.PMS.FullText.Core/Collections/LFUCache.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/LFUCache.cs
@@ -6,9 +6,8 @@ namespace Protsyk.PMS.FullText.Core.Collections
 {
     public class LFUCache<TKey, TValue>
     {
-        private readonly GenericHeap<ValueTuple<int, int, TKey>> h = new GenericHeap<ValueTuple<int, int, TKey>>();
-        private readonly Dictionary<TKey, ValueTuple<TValue, GenericHeap<ValueTuple<int, int, TKey>>.IItemReference>> c
-                                    = new Dictionary<TKey, (TValue, GenericHeap<ValueTuple<int, int, TKey>>.IItemReference)>();
+        private readonly GenericHeap<ValueTuple<int, int, TKey>> h = new();
+        private readonly Dictionary<TKey, ValueTuple<TValue, GenericHeap<ValueTuple<int, int, TKey>>.IItemReference>> c = new();
         private readonly int capacity;
         private int nextOrder;
 
@@ -67,7 +66,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
         {
             if (!c.TryGetValue(key, out var valref))
             {
-                value = default(TValue);
+                value = default;
                 return false;
             }
             else

--- a/Src/Protsyk.PMS.FullText.Core/Collections/PersistentDictionary.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/PersistentDictionary.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Buffers.Binary;
+
 using Protsyk.PMS.FullText.Core.Common.Persistance;
 
 namespace Protsyk.PMS.FullText.Core.Collections
@@ -50,8 +52,8 @@ namespace Protsyk.PMS.FullText.Core.Collections
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
-                dataStorage.ReadAll(offset, sizeBuffer, 0, sizeBuffer.Length);
-                int dataSize = BitConverter.ToInt32(sizeBuffer, 0);
+                dataStorage.ReadAll(offset, sizeBuffer);
+                int dataSize = BinaryPrimitives.ReadInt32LittleEndian(sizeBuffer);
 
                 //TODO: Improve serializer, no need to reallocate
                 if (valueBuffer == null || valueBuffer.Length != dataSize)
@@ -59,7 +61,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
                     valueBuffer = new byte[dataSize];
                 }
 
-                dataStorage.ReadAll(offset + sizeBuffer.Length, valueBuffer, 0, valueBuffer.Length);
+                dataStorage.ReadAll(offset + sizeBuffer.Length, valueBuffer);
 
                 return valueSerializer.GetValue(valueBuffer);
             }
@@ -73,10 +75,9 @@ namespace Protsyk.PMS.FullText.Core.Collections
                 }
 
                 var data = valueSerializer.GetBytes(value);
-                var dataSize = BitConverter.GetBytes(data.Length);
 
-                dataStorage.WriteAll(offset, dataSize, 0, dataSize.Length);
-                dataStorage.WriteAll(offset + dataSize.Length, data, 0, data.Length);
+                dataStorage.WriteInt32LittleEndian(offset, data.Length);
+                dataStorage.WriteAll(offset + sizeof(int), data);
             }
         }
         #endregion

--- a/Src/Protsyk.PMS.FullText.Core/Collections/PersistentHashTable.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/PersistentHashTable.cs
@@ -11,8 +11,8 @@ namespace Protsyk.PMS.FullText.Core.Collections
     public class PersistentHashTable<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>, IDisposable
     {
         #region Fields
-        private static readonly int MinValueBufferSize = 256;
-        private static readonly int MinCapacity = 8;
+        private const int MinValueBufferSize = 256;
+        private const int MinCapacity = 8;
         private static readonly byte[] Header = "PMS-HASH"u8.ToArray();
         private static readonly int HeaderSize = Header.Length;
         private static readonly int IndexRecordSize = sizeof(long) + sizeof(int);
@@ -26,7 +26,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
         private byte[] valueBuffer;
         private int capacity;
         private int count;
-        private int headerSize;
+        private readonly int headerSize;
         #endregion
 
         #region Properties

--- a/Src/Protsyk.PMS.FullText.Core/Collections/TernaryDictionary.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/TernaryDictionary.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
-
 using Protsyk.PMS.FullText.Core.Common.Persistance;
 
 namespace Protsyk.PMS.FullText.Core.Collections
@@ -561,7 +560,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
 
             public void ReadHeader(IPersistentStorage persistentStorage)
             {
-                persistentStorage.ReadAll(0, headerData, 0, headerData.Length);
+                persistentStorage.ReadAll(0, headerData);
 
                 if (Text != HeaderText)
                 {
@@ -572,7 +571,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
 
             public void SaveHeader(IPersistentStorage persistentStorage)
             {
-                persistentStorage.WriteAll(0, headerData, 0, headerData.Length);
+                persistentStorage.WriteAll(0, headerData);
             }
         }
 
@@ -740,14 +739,14 @@ namespace Protsyk.PMS.FullText.Core.Collections
                 var offset = CalculateNodeOffset(id);
                 var data = new byte[NodeData.Size(keySerializer.Size + valueSerializer.Size)];
 
-                persistentStorage.ReadAll(offset, data, 0, data.Length);
+                persistentStorage.ReadAll(offset, data);
                 return new NodeData(keySerializer, valueSerializer, data);
             }
 
             private void Save(in NodeData node)
             {
                 var offset = CalculateNodeOffset(node.Id);
-                persistentStorage.WriteAll(offset, node.Data, 0, node.Data.Length);
+                persistentStorage.WriteAll(offset, node.Data);
             }
 
             private void SaveHeader(Header newHeader)

--- a/Src/Protsyk.PMS.FullText.Core/Collections/TernaryDictionary.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/TernaryDictionary.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -21,7 +22,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
         private readonly IFixedSizeDataSerializer<TValue> valueSerializer;
 
         private readonly IComparer<TKey> comparer;
-        private NodeManager nodeManager;
+        private readonly NodeManager nodeManager;
         #endregion
 
         #region Properties
@@ -177,7 +178,6 @@ namespace Protsyk.PMS.FullText.Core.Collections
                 return inserted;
             }
         }
-
 
         /// <summary>
         /// Match values in the tree
@@ -424,6 +424,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
                 set
                 {
                     var splitData = keySerializer.GetBytes(value);
+
                     Array.Copy(splitData, 0, data, 0, splitData.Length);
                 }
             }
@@ -470,7 +471,9 @@ namespace Protsyk.PMS.FullText.Core.Collections
 
             private void SetInt(int value, int index)
             {
-                Array.Copy(BitConverter.GetBytes(value), 0, data, valueSerializer.Size + keySerializer.Size + 1 + sizeof(int) * index, sizeof(int));
+                int offset = valueSerializer.Size + keySerializer.Size + 1 + sizeof(int) * index;
+
+                BinaryPrimitives.WriteInt32LittleEndian(data.AsSpan(offset), value);
             }
 
             private int GetInt(int index)
@@ -484,9 +487,9 @@ namespace Protsyk.PMS.FullText.Core.Collections
             }
         }
 
-        private class Header
+        private sealed class Header
         {
-            private static readonly string HeaderText = "TDict-v01";
+            private static ReadOnlySpan<byte> HeaderBytes => "TDict-v01"u8;
             private readonly byte[] headerData;
 
             public byte[] Data
@@ -496,8 +499,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
 
             private string Text
             {
-                get { return Encoding.UTF8.GetString(headerData, 0, HeaderText.Length); }
-                set { Array.Copy(Encoding.UTF8.GetBytes(HeaderText), 0, headerData, 0, HeaderText.Length); }
+                get { return Encoding.UTF8.GetString(headerData, 0, HeaderBytes.Length); }
             }
 
             public int Count
@@ -520,17 +522,16 @@ namespace Protsyk.PMS.FullText.Core.Collections
 
             private void SetInHeader(int value, int index)
             {
-                Array.Copy(BitConverter.GetBytes(value), 0, headerData, HeaderText.Length + sizeof(int) * index, sizeof(int));
+                Array.Copy(BitConverter.GetBytes(value), 0, headerData, HeaderBytes.Length + sizeof(int) * index, sizeof(int));
             }
 
             private int GetInHeader(int index)
             {
-                return BitConverter.ToInt32(headerData, HeaderText.Length + sizeof(int) * index);
+                return BitConverter.ToInt32(headerData, HeaderBytes.Length + sizeof(int) * index);
             }
 
-
             public Header()
-                : this(new byte[HeaderText.Length + 4 * sizeof(int)])
+                : this(new byte[HeaderBytes.Length + 4 * sizeof(int)])
             {
                 CleanHeader();
             }
@@ -545,13 +546,15 @@ namespace Protsyk.PMS.FullText.Core.Collections
             public Header Copy()
             {
                 var data = new byte[headerData.Length];
-                Array.Copy(headerData, 0, data, 0, data.Length);
+
+                headerData.CopyTo(data.AsSpan());
+
                 return new Header(data);
             }
 
             public void CleanHeader()
             {
-                Text = HeaderText;
+                HeaderBytes.CopyTo(headerData);
                 Count = 0;
                 NextId = 1;
                 RootNodeId = NodeManager.NewId;
@@ -561,12 +564,11 @@ namespace Protsyk.PMS.FullText.Core.Collections
             {
                 persistentStorage.ReadAll(0, headerData);
 
-                if (Text != HeaderText)
+                if (!headerData.AsSpan(0, HeaderBytes.Length).SequenceEqual(HeaderBytes))
                 {
                     throw new InvalidOperationException("Header text mismatch");
                 }
             }
-
 
             public void SaveHeader(IPersistentStorage persistentStorage)
             {
@@ -588,19 +590,16 @@ namespace Protsyk.PMS.FullText.Core.Collections
             private readonly ITransaction transaction;
             private bool finalized;
 
-
             public Update(ITransaction transaction)
             {
                 this.transaction = transaction;
                 this.finalized = false;
             }
 
-
             public void Dispose()
             {
                 Rollback();
             }
-
 
             public void Commit()
             {

--- a/Src/Protsyk.PMS.FullText.Core/Collections/TernaryDictionary.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/TernaryDictionary.cs
@@ -338,8 +338,7 @@ namespace Protsyk.PMS.FullText.Core.Collections
 
                 if (node.Eqkid != NodeManager.NoId)
                 {
-                    int childIndex;
-                    if (!labels.TryGetValue(node.Eqkid, out childIndex))
+                    if (!labels.TryGetValue(node.Eqkid, out int childIndex))
                     {
                         childIndex = labels.Count + 1;
                         labels.Add(node.Eqkid, childIndex);
@@ -646,8 +645,8 @@ namespace Protsyk.PMS.FullText.Core.Collections
 
         private sealed class NodeManager : IDisposable
         {
-            public static readonly int NewId = -1;
-            public static readonly int NoId = 0;
+            public const int NewId = -1;
+            public const int NoId = 0;
 
             private readonly IPersistentStorage persistentStorage;
             private readonly IFixedSizeDataSerializer<TKey> keySerializer;

--- a/Src/Protsyk.PMS.FullText.Core/Common/Compression/CombinationList.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Compression/CombinationList.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace Protsyk.PMS.FullText.Core.Common.Compression
@@ -219,7 +219,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Compression
                     if (r is TreeLeaf)
                         sb.Append(r.w);
                     else
-                        sb.Append("(" + r.w + ")");
+                        sb.Append(CultureInfo.InvariantCulture, $"({r.w})");
 
                     if (r.Next != null)
                     {

--- a/Src/Protsyk.PMS.FullText.Core/Common/Compression/DecodingMatcher.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Compression/DecodingMatcher.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Text;
+
 using Protsyk.PMS.FullText.Core.Collections;
 
 namespace Protsyk.PMS.FullText.Core.Common.Compression
 {
-    internal class DecodingMatcher : IDfaMatcher<byte>
+    internal sealed class DecodingMatcher : IDfaMatcher<byte>
     {
         private readonly IDfaMatcher<char> matcher;
         private readonly int maxLength;
@@ -62,5 +62,4 @@ namespace Protsyk.PMS.FullText.Core.Common.Compression
             matcher.Reset();
         }
     }
-
 }

--- a/Src/Protsyk.PMS.FullText.Core/Common/Compression/DecodingMatcherForUTF8.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Compression/DecodingMatcherForUTF8.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Text;
+
 using Protsyk.PMS.FullText.Core.Collections;
 
 namespace Protsyk.PMS.FullText.Core.Common.Compression
 {
-    internal class DecodingMatcherForUTF8 : IDfaMatcher<byte>
+    internal sealed class DecodingMatcherForUTF8 : IDfaMatcher<byte>
     {
         private readonly IDfaMatcher<char> matcher;
         private int symbol;

--- a/Src/Protsyk.PMS.FullText.Core/Common/Compression/DecodingMatcherForVarLenCharEncoding.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Compression/DecodingMatcherForVarLenCharEncoding.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+
 using Protsyk.PMS.FullText.Core.Collections;
 
 namespace Protsyk.PMS.FullText.Core.Common.Compression
 {
-    internal class DecodingMatcherForVarLenCharEncoding : IDfaMatcher<byte>
+    internal sealed class DecodingMatcherForVarLenCharEncoding : IDfaMatcher<byte>
     {
         private readonly IDfaMatcher<char> matcher;
         private readonly VarLenCharEncoding encoding;

--- a/Src/Protsyk.PMS.FullText.Core/Common/Compression/HuTuckerBuilder.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Compression/HuTuckerBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Protsyk.PMS.FullText.Core.Common.Compression
 {

--- a/Src/Protsyk.PMS.FullText.Core/Common/GroupVarInt.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/GroupVarInt.cs
@@ -288,7 +288,7 @@ namespace Protsyk.PMS.FullText.Core
                 result.Append(Convert.ToString(code[i], 2).PadLeft(8, '0'));
                 if (i != code.Count - 1)
                 {
-                    result.Append(" ");
+                    result.Append(' ');
                 }
             }
             return result.ToString();

--- a/Src/Protsyk.PMS.FullText.Core/Common/Numeric.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Numeric.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 
 namespace Protsyk.PMS.FullText.Core.Common
 {
@@ -46,19 +47,15 @@ namespace Protsyk.PMS.FullText.Core.Common
 
         public static int WriteInt(int value, byte[] buffer, int startIndex)
         {
-            buffer[startIndex] = (byte)value;
-            buffer[startIndex + 1] = (byte)(value >> 8);
-            buffer[startIndex + 2] = (byte)(value >> 16);
-            buffer[startIndex + 3] = (byte)(value >> 24);
+            BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(startIndex), value);
+
             return 4;
         }
 
-        public static int WriteUInt(uint x, byte[] buffer, int startIndex)
+        public static int WriteUInt(uint value, byte[] buffer, int startIndex)
         {
-            buffer[startIndex] = (byte)x;
-            buffer[startIndex + 1] = (byte)(x >> 8);
-            buffer[startIndex + 2] = (byte)(x >> 16);
-            buffer[startIndex + 3] = (byte)(x >> 24);
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(startIndex), value);
+
             return 4;
         }
     }

--- a/Src/Protsyk.PMS.FullText.Core/Common/Numeric.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Numeric.cs
@@ -9,10 +9,13 @@ namespace Protsyk.PMS.FullText.Core.Common
             if (typeSize <= 0 || typeSize > sizeof(long))
                 throw new ArgumentOutOfRangeException();
 
-            if (typeSize == 8) return ulong.MaxValue;
-            if (typeSize == 4) return uint.MaxValue;
-            if (typeSize == 2) return ushort.MaxValue;
-            if (typeSize == 1) return byte.MaxValue;
+            switch (typeSize)
+            {
+                case 8: return ulong.MaxValue;
+                case 4: return uint.MaxValue;
+                case 2: return ushort.MaxValue;
+                case 1: return byte.MaxValue;
+            }
 
             checked
             {

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/DataSerializer.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/DataSerializer.cs
@@ -29,7 +29,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
 
     public static class DataSerializer
     {
-        private static readonly Dictionary<Type, Func<object>> factories = new Dictionary<Type, Func<object>>()
+        private static readonly Dictionary<Type, Func<object>> factories = new()
                                                                             {
                                                                                {typeof(byte), () => new ByteDataSerializer() },
                                                                                {typeof(char), () => new CharDataSerializer()},

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/DataSerializer.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/DataSerializer.cs
@@ -63,7 +63,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         }
     }
 
-    internal class ByteDataSerializer : IFixedSizeDataSerializer<byte>
+    internal sealed class ByteDataSerializer : IFixedSizeDataSerializer<byte>
     {
         public int Size => 1;
 
@@ -88,7 +88,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         }
     }
 
-    internal class StringDataSerializer : IDataSerializer<string>
+    internal sealed class StringDataSerializer : IDataSerializer<string>
     {
         public byte[] GetBytes(string value)
         {
@@ -112,7 +112,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         }
     }
 
-    internal class IntDataSerializer : IFixedSizeDataSerializer<int>
+    internal sealed class IntDataSerializer : IFixedSizeDataSerializer<int>
     {
         public int Size => sizeof(int);
 
@@ -137,7 +137,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         }
     }
 
-    internal class LongDataSerializer : IFixedSizeDataSerializer<long>
+    internal sealed class LongDataSerializer : IFixedSizeDataSerializer<long>
     {
         public int Size => sizeof(long);
 
@@ -162,7 +162,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         }
     }
 
-    internal class ULongDataSerializer : IFixedSizeDataSerializer<ulong>
+    internal sealed class ULongDataSerializer : IFixedSizeDataSerializer<ulong>
     {
         public int Size => sizeof(ulong);
 
@@ -187,7 +187,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         }
     }
 
-    internal class GuidDataSerializer : IFixedSizeDataSerializer<Guid>
+    internal sealed class GuidDataSerializer : IFixedSizeDataSerializer<Guid>
     {
         public int Size => 16;
 
@@ -223,7 +223,7 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         }
     }
 
-    internal class CharDataSerializer : IFixedSizeDataSerializer<char>
+    internal sealed class CharDataSerializer : IFixedSizeDataSerializer<char>
     {
         public int Size => sizeof(char);
 
@@ -248,11 +248,11 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         }
     }
 
-    internal class NoValueSerializer : IFixedSizeDataSerializer<NoValue>
+    internal sealed class NoValueSerializer : IFixedSizeDataSerializer<NoValue>
     {
         public byte[] GetBytes(NoValue value)
         {
-            return new byte[0];
+            return Array.Empty<byte>();
         }
 
         public int GetByteSize(NoValue value)

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/FileStorage.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/FileStorage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace Protsyk.PMS.FullText.Core.Common.Persistance
 {

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Text;
 
 namespace Protsyk.PMS.FullText.Core.Common.Persistance
@@ -22,6 +23,38 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
             {
                 ArrayPool<byte>.Shared.Return(rentedBuffer);
             }
+        }
+
+        public static int WriteInt32LittleEndian(this IPersistentStorage storage, long fileOffset, int value)
+        {
+            Span<byte> buffer = stackalloc byte[4];
+
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
+
+            storage.WriteAll(fileOffset, buffer);
+
+            return 4;
+        }
+
+        public static int WriteInt64LittleEndian(this IPersistentStorage storage, long fileOffset, long value)
+        {
+            Span<byte> buffer = stackalloc byte[8];
+
+            BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
+
+            storage.WriteAll(fileOffset, buffer);
+
+            return 8;
+        }
+
+        public static int AppendInt32LittleEndian(this IPersistentStorage storage, int value)
+        {
+            return WriteInt32LittleEndian(storage, storage.Length, value);
+        }
+
+        public static int AppendInt64LittleEndian(this IPersistentStorage storage, long value)
+        {
+            return WriteInt64LittleEndian(storage, storage.Length, value);
         }
     }
 }

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
@@ -7,6 +7,11 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
 {
     internal static class IPersistentStorageExtensions
     {
+        public static void Append(this IPersistentStorage storage, ReadOnlySpan<byte> bytes)
+        {
+            storage.WriteAll(storage.Length, bytes);
+        }
+
         public static int AppendUtf8Bytes(this IPersistentStorage storage, ReadOnlySpan<char> chars)
         {
             var rentedBuffer = ArrayPool<byte>.Shared.Rent(Encoding.UTF8.GetMaxByteCount(chars.Length));

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Buffers;
+using System.Text;
+
+namespace Protsyk.PMS.FullText.Core.Common.Persistance
+{
+    internal static class IPersistentStorageExtensions
+    {
+        public static int AppendUtf8Bytes(this IPersistentStorage storage, ReadOnlySpan<char> chars)
+        {
+            var rentedBuffer = ArrayPool<byte>.Shared.Rent(Encoding.UTF8.GetMaxByteCount(chars.Length));
+
+            try
+            {
+                var byteCount = Encoding.UTF8.GetBytes(chars, rentedBuffer);
+
+                storage.WriteAll(storage.Length, rentedBuffer.AsSpan(0, byteCount));
+
+                return byteCount;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rentedBuffer);
+            }
+        }
+    }
+}

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
@@ -56,5 +56,14 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
         {
             return WriteInt64LittleEndian(storage, storage.Length, value);
         }
+
+        public static long ReadInt64LittleEndian(this IPersistentStorage storage, long fileOffset)
+        {
+            Span<byte> buffer = stackalloc byte[8];
+
+            storage.ReadAll(fileOffset, buffer);
+            
+            return BinaryPrimitives.ReadInt64LittleEndian(buffer);
+        }
     }
 }

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/IPersistentStorageExtensions.cs
@@ -65,5 +65,14 @@ namespace Protsyk.PMS.FullText.Core.Common.Persistance
             
             return BinaryPrimitives.ReadInt64LittleEndian(buffer);
         }
+
+        public static int ReadInt32LittleEndian(this IPersistentStorage storage, long fileOffset)
+        {
+            Span<byte> buffer = stackalloc byte[4];
+
+            storage.ReadAll(fileOffset, buffer);
+
+            return BinaryPrimitives.ReadInt32LittleEndian(buffer);
+        }
     }
 }

--- a/Src/Protsyk.PMS.FullText.Core/Common/Persistance/NullTextWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/Persistance/NullTextWriter.cs
@@ -1,6 +1,4 @@
-﻿
-using System;
-using System.IO;
+﻿using System.IO;
 using System.Text;
 
 namespace Protsyk.PMS.FullText.Core.Common.Persistance

--- a/Src/Protsyk.PMS.FullText.Core/Common/StringComparer.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/StringComparer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Protsyk.PMS.FullText.Core.Common
 {
@@ -23,5 +21,4 @@ namespace Protsyk.PMS.FullText.Core.Common
             return h;
         }
     }
-
 }

--- a/Src/Protsyk.PMS.FullText.Core/IndexModels/BasicSkipList.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexModels/BasicSkipList.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Protsyk.PMS.FullText.Core
 {
-    internal class BasicSkipList : ISkipList
+    internal sealed class BasicSkipList : ISkipList
     {
         private readonly IPostingList list;
 

--- a/Src/Protsyk.PMS.FullText.Core/IndexModels/DictionaryTerm.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexModels/DictionaryTerm.cs
@@ -15,12 +15,12 @@ namespace Protsyk.PMS.FullText.Core
 
         public override bool Equals(object obj)
         {
-            return obj is DictionaryTerm && Equals((DictionaryTerm)obj);
+            return obj is DictionaryTerm other && Equals(other);
         }
 
         public bool Equals(DictionaryTerm other)
         {
-            return string.Equals(Key, other.Key) && Value.Equals(other.Value);
+            return string.Equals(Key, other.Key, StringComparison.Ordinal) && Value.Equals(other.Value);
         }
 
         public override int GetHashCode()

--- a/Src/Protsyk.PMS.FullText.Core/IndexModels/PostingListExtensions.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexModels/PostingListExtensions.cs
@@ -1,13 +1,10 @@
-﻿using System.Collections.Generic;
-
-namespace Protsyk.PMS.FullText.Core
+﻿namespace Protsyk.PMS.FullText.Core
 {
     public static class PostingListExtensions
     {
         public static ISkipList AsSkipList(this IPostingList list)
         {
-            var native = list as ISkipList;
-            if (native != null)
+            if (list is ISkipList native)
             {
                 return native;
             }
@@ -15,5 +12,4 @@ namespace Protsyk.PMS.FullText.Core
             return new BasicSkipList(list);
         }
     }
-
 }

--- a/Src/Protsyk.PMS.FullText.Core/IndexModels/TextPosition.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexModels/TextPosition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Protsyk.PMS.FullText.Core
@@ -32,8 +33,8 @@ namespace Protsyk.PMS.FullText.Core
             }
 
             return P(
-                int.Parse(match.Groups["offset"].Value),
-                int.Parse(match.Groups["length"].Value));
+                int.Parse(match.Groups["offset"].ValueSpan),
+                int.Parse(match.Groups["length"].ValueSpan));
         }
         #endregion
 
@@ -54,7 +55,7 @@ namespace Protsyk.PMS.FullText.Core
 
         public override string ToString()
         {
-            return $"[{Offset},{Length}]";
+            return string.Create(CultureInfo.InvariantCulture, $"[{Offset},{Length}]");
         }
         #endregion
 

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Common/BasicTokenizer.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Common/BasicTokenizer.cs
@@ -102,7 +102,7 @@ namespace Protsyk.PMS.FullText.Core
                 return true;
             }
 
-            if (c == '-' || c == '_')
+            if (c is '-' or '_')
             {
                 return true;
             }

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Common/SequenceMatch.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Common/SequenceMatch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Protsyk.PMS.FullText.Core

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/ITermDictionary.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/ITermDictionary.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Protsyk.PMS.FullText.Core.Collections;
 
 namespace Protsyk.PMS.FullText.Core

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/InMemory/InMemoryBuilder.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/InMemory/InMemoryBuilder.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Protsyk.PMS.FullText.Core
 {
-    internal class InMemoryBuilder : FullTextIndexBuilder
+    internal sealed class InMemoryBuilder : FullTextIndexBuilder
     {
         private readonly InMemoryIndexName name;
 

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/InMemory/InMemoryIndex.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/InMemory/InMemoryIndex.cs
@@ -8,17 +8,17 @@ using Protsyk.PMS.FullText.Core.Collections;
 
 namespace Protsyk.PMS.FullText.Core
 {
-    internal class InMemoryIndex : ITermDictionary, IPostingLists, IIndexName, IFullTextIndex, IMetadataStorage<string>
+    internal sealed class InMemoryIndex : ITermDictionary, IPostingLists, IIndexName, IFullTextIndex, IMetadataStorage<string>
     {
         #region Fields
         private const int MaxTokenSize = 64;
 
-        private readonly ConcurrentDictionary<string, PostingListAddress> data = new ConcurrentDictionary<string, PostingListAddress>();
-        private readonly ConcurrentDictionary<PostingListAddress, Occurrence[]> postingLists = new ConcurrentDictionary<PostingListAddress, Occurrence[]>();
-        private readonly ConcurrentDictionary<ulong, string> fields = new ConcurrentDictionary<ulong, string>();
-        private readonly ConcurrentDictionary<ValueTuple<ulong, ulong>, PostingListAddress> posIndex = new ConcurrentDictionary<(ulong, ulong), PostingListAddress>();
-        private readonly ConcurrentDictionary<PostingListAddress, TextPosition[]> positions = new ConcurrentDictionary<PostingListAddress, TextPosition[]>();
-        private readonly ConcurrentDictionary<ValueTuple<ulong, ulong>, string> docTexts = new ConcurrentDictionary<(ulong, ulong), string>();
+        private readonly ConcurrentDictionary<string, PostingListAddress> data = new();
+        private readonly ConcurrentDictionary<PostingListAddress, Occurrence[]> postingLists = new();
+        private readonly ConcurrentDictionary<ulong, string> fields = new();
+        private readonly ConcurrentDictionary<ValueTuple<ulong, ulong>, PostingListAddress> posIndex = new();
+        private readonly ConcurrentDictionary<PostingListAddress, TextPosition[]> positions = new();
+        private readonly ConcurrentDictionary<ValueTuple<ulong, ulong>, string> docTexts = new();
         #endregion
 
         #region Constructor

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Parser/QueryParser.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Parser/QueryParser.cs
@@ -6,7 +6,7 @@ namespace Protsyk.PMS.FullText.Core
 {
     public class QueryParser
     {
-        private static readonly Dictionary<string, Func<string, int, string, ParseResult>> argumentsParsers = new Dictionary<string, Func<string, int, string, ParseResult>>
+        private static readonly Dictionary<string, Func<string, int, string, ParseResult>> argumentsParsers = new()
         {
             { "OR", ParseArguments },
             { "AND", ParseArguments },
@@ -159,7 +159,7 @@ namespace Protsyk.PMS.FullText.Core
                     escaped.Append('\\');
                     pos = ParseEscapedCharacter(s, pos);
                 }
-                else if (s[pos] == '*' || s[pos] == '?')
+                else if (s[pos] is '*' or '?')
                 {
                     // Accepted wildcard characters
                 }
@@ -244,7 +244,7 @@ namespace Protsyk.PMS.FullText.Core
             return pos;
         }
 
-        private struct ParseResult
+        private readonly struct ParseResult
         {
             public readonly AstQuery query;
             public readonly int position;

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/DeltaVarIntListReader.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/DeltaVarIntListReader.cs
@@ -42,11 +42,9 @@ namespace Protsyk.PMS.FullText.Core
             var result = new StringBuilder();
             var buffer = new byte[4096];
             var offset = textStart;
-            var chunkSize = 0;
 
-            persistentStorage.ReadAll(offset, buffer, 0, sizeof(int));
+            int chunkSize = persistentStorage.ReadInt32LittleEndian(offset);
             offset += sizeof(int);
-            chunkSize = BinaryPrimitives.ReadInt32LittleEndian(buffer);
             while(chunkSize > 0)
             {
                 if (buffer.Length < chunkSize)
@@ -54,14 +52,13 @@ namespace Protsyk.PMS.FullText.Core
                     buffer = new byte[4096 * ((chunkSize+4095)/4096)];
                 }
 
-                persistentStorage.ReadAll(offset, buffer, 0, chunkSize);
+                persistentStorage.ReadAll(offset, buffer.AsSpan(0, chunkSize));
                 offset += chunkSize;
 
                 result.Append(Encoding.UTF8.GetString(buffer, 0, chunkSize));
 
-                persistentStorage.ReadAll(offset, buffer, 0, sizeof(int));
+                chunkSize = persistentStorage.ReadInt32LittleEndian(offset);
                 offset += sizeof(int);
-                chunkSize = BinaryPrimitives.ReadInt32LittleEndian(buffer);
             }
             return new StringReader(result.ToString());
         }

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/IOccurrenceReader.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/IOccurrenceReader.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Protsyk.PMS.FullText.Core
+﻿namespace Protsyk.PMS.FullText.Core
 {
     public interface IOccurrenceReader : IPostingLists
     {

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/IOccurrenceWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/IOccurrenceWriter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Protsyk.PMS.FullText.Core
 {

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentDictionaryFst.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentDictionaryFst.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+
 using Protsyk.PMS.FullText.Core.Automata;
 using Protsyk.PMS.FullText.Core.Collections;
 using Protsyk.PMS.FullText.Core.Common.Compression;
@@ -43,7 +43,7 @@ namespace Protsyk.PMS.FullText.Core
             if (storage.Length > 0)
             {
                 var buffer = new byte[storage.Length];
-                storage.ReadAll(0, buffer, 0, buffer.Length);
+                storage.ReadAll(0, buffer);
                 this.fst = FST<int>.FromBytesCompressed(buffer, FSTVarIntOutput.Instance);
             }
         }
@@ -54,8 +54,7 @@ namespace Protsyk.PMS.FullText.Core
         {
             // var decodingMatcher = encoding.CreateMatcher(matcher.ToDfaMatcher(), maxTokenByteLength);
 
-            foreach (var term in fst.Match(matcher.ToDfaMatcher())
-                                    .Select(p => new string(p.ToArray())))
+            foreach (var term in fst.Match(matcher.ToDfaMatcher()))
             {
                 yield return GetTerm(term);
             }
@@ -84,7 +83,7 @@ namespace Protsyk.PMS.FullText.Core
         {
             private List<string> input = new List<string>();
             private List<int> output = new List<int>();
-            private IPersistentStorage storage;
+            private readonly IPersistentStorage storage;
 
             public Update(IPersistentStorage storage)
             {
@@ -103,7 +102,7 @@ namespace Protsyk.PMS.FullText.Core
                     Validate(fst); //TODO: Optional
                     {
                         var fstData = fst.GetBytesCompressed();
-                        storage.WriteAll(0, fstData, 0, fstData.Length);
+                        storage.WriteAll(0, fstData);
                     }
                     input = null;
                     output = null;
@@ -148,10 +147,8 @@ namespace Protsyk.PMS.FullText.Core
                 throw new NotSupportedException("It is not possible to update FST");
             }
 
-            if (update == null)
-            {
-                update = new Update(storage);
-            }
+            update ??= new Update(storage);
+
             return update;
         }
 

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentIndexInfo.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentIndexInfo.cs
@@ -6,7 +6,7 @@ using Protsyk.PMS.FullText.Core.Common.Persistance;
 
 namespace Protsyk.PMS.FullText.Core
 {
-    internal class PersistentIndexInfo : IDisposable
+    internal sealed class PersistentIndexInfo : IDisposable
     {
         private readonly FileStorage persistentStorage;
 

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentMetadataBtree.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentMetadataBtree.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
+
 using Protsyk.PMS.FullText.Core.Collections;
 using Protsyk.PMS.FullText.Core.Common.Persistance;
 
 namespace Protsyk.PMS.FullText.Core
 {
-    internal class PersistentMetadataBtree : IMetadataStorage<string>
+    internal sealed class PersistentMetadataBtree : IMetadataStorage<string>
     {
-        private BtreePersistent<ulong, string> fields;
+        private readonly BtreePersistent<ulong, string> fields;
 
         public static readonly string Id = "BTree";
 

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentMetadataFactory.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentMetadataFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 
 namespace Protsyk.PMS.FullText.Core
 {

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentMetadataHashTable.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentMetadataHashTable.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+
 using Protsyk.PMS.FullText.Core.Collections;
 using Protsyk.PMS.FullText.Core.Common.Persistance;
 
 namespace Protsyk.PMS.FullText.Core
 {
-    internal class PersistentMetadataHashTable : IMetadataStorage<string>
+    internal sealed class PersistentMetadataHashTable : IMetadataStorage<string>
     {
         private const int InitialHashCapacity = 65536;
 

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentMetadataList.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PersistentMetadataList.cs
@@ -5,7 +5,7 @@ using Protsyk.PMS.FullText.Core.Common.Persistance;
 
 namespace Protsyk.PMS.FullText.Core
 {
-    internal class PersistentMetadataList : IMetadataStorage<string>
+    internal sealed class PersistentMetadataList : IMetadataStorage<string>
     {
         private PersistentDictionary<string> fields;
         public static readonly string Id = "List";

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListBinaryDeltaWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListBinaryDeltaWriter.cs
@@ -229,12 +229,10 @@ namespace Protsyk.PMS.FullText.Core
 
         public void UpdateNextList(PostingListAddress address, PostingListAddress nextList)
         {
-            Span<byte> buffer = stackalloc byte[8];
             var offset = address.Offset;
             while (true)
             {
-                persistentStorage.ReadAll(offset, buffer);
-                long continuationOffset = BinaryPrimitives.ReadInt64LittleEndian(buffer);
+                long continuationOffset = persistentStorage.ReadInt64LittleEndian(offset);
 
                 if (continuationOffset == 0)
                 {

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListBinaryWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListBinaryWriter.cs
@@ -130,12 +130,10 @@ namespace Protsyk.PMS.FullText.Core
 
         public void UpdateNextList(PostingListAddress address, PostingListAddress nextList)
         {
-            Span<byte> buffer = stackalloc byte[8];
-            var offset = address.Offset;
+            long offset = address.Offset;
             while (true)
             {
-                persistentStorage.ReadAll(offset, buffer);
-                long continuationOffset = BinaryPrimitives.ReadInt64LittleEndian(buffer);
+                long continuationOffset = persistentStorage.ReadInt64LittleEndian(offset);
 
                 if (continuationOffset == 0)
                 {

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListBinaryWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListBinaryWriter.cs
@@ -43,10 +43,10 @@ namespace Protsyk.PMS.FullText.Core
             listStart = persistentStorage.Length;
 
             // Reserve space for continuation offset
-            persistentStorage.WriteAll(listStart, BitConverter.GetBytes(0L), 0, sizeof(long));
+            persistentStorage.WriteInt64LittleEndian(listStart, 0L);
 
             // Reserve space for the length of the list
-            persistentStorage.WriteAll(listStart + sizeof(long), BitConverter.GetBytes(0), 0, sizeof(int));
+            persistentStorage.WriteInt32LittleEndian(listStart + sizeof(long), 0);
         }
 
         public void AddOccurrence(Occurrence occurrence)
@@ -116,7 +116,7 @@ namespace Protsyk.PMS.FullText.Core
             FlushBuffer();
 
             // Write the length of the list
-            persistentStorage.WriteAll(listStart + sizeof(long), BitConverter.GetBytes(totalSize), 0, sizeof(int));
+            persistentStorage.WriteInt32LittleEndian(listStart + sizeof(long), totalSize);
 
             var listEnd = persistentStorage.Length;
 
@@ -139,7 +139,7 @@ namespace Protsyk.PMS.FullText.Core
 
                 if (continuationOffset == 0)
                 {
-                    persistentStorage.WriteAll(offset, BitConverter.GetBytes(nextList.Offset), 0, sizeof(long));
+                    persistentStorage.WriteInt64LittleEndian(offset, nextList.Offset);
                     break;
                 }
                 else

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListPackedIntDeltaReader.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListPackedIntDeltaReader.cs
@@ -121,7 +121,7 @@ namespace Protsyk.PMS.FullText.Core
                     }
                     else
                     {
-                        persistentStorage.ReadAll(readOffset, buffer, dataInBuffer, toRead);
+                        persistentStorage.ReadAll(readOffset, buffer.AsSpan(dataInBuffer, toRead));
                         readOffset += toRead;
                         dataInBuffer += toRead;
                     }
@@ -186,7 +186,7 @@ namespace Protsyk.PMS.FullText.Core
                         }
 
                         var headerBuffer = new byte[HeaderLength];
-                        persistentStorage.ReadAll(readOffset, headerBuffer, 0, headerBuffer.Length);
+                        persistentStorage.ReadAll(readOffset, headerBuffer);
 
                         continuationOffset = BitConverter.ToInt64(headerBuffer, 0);
                         listEndOffset = readOffset + HeaderLength + BitConverter.ToInt32(headerBuffer, sizeof(long));

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListPackedIntDeltaWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListPackedIntDeltaWriter.cs
@@ -142,7 +142,7 @@ namespace Protsyk.PMS.FullText.Core
                     if (remainingBlocks == 1)
                     {
                         var packed = PackedInts.Convert(buffer, 0, bufferIndex).GetBytes();
-                        persistentStorage.WriteAll(persistentStorage.Length, packed, 0, packed.Length);
+                        persistentStorage.WriteAll(persistentStorage.Length, packed);
                         totalSize += packed.Length;
 
                         deltaSelectorIndex = 0;
@@ -167,7 +167,7 @@ namespace Protsyk.PMS.FullText.Core
                 buffer[deltaSelectorIndex] = deltaSelector;
 
                 var packed = PackedInts.Convert(buffer, 0, bufferIndex).GetBytes();
-                persistentStorage.WriteAll(persistentStorage.Length, packed, 0, packed.Length);
+                persistentStorage.WriteAll(persistentStorage.Length, packed);
 
                 totalSize += packed.Length;
             }

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListPackedIntDeltaWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListPackedIntDeltaWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.IO;
 using Protsyk.PMS.FullText.Core.Common.Persistance;
 
@@ -53,10 +54,10 @@ namespace Protsyk.PMS.FullText.Core
             listStart = persistentStorage.Length;
 
             // Reserve space for continuation offset
-            persistentStorage.WriteAll(listStart, BitConverter.GetBytes(0L), 0, sizeof(long));
+            persistentStorage.WriteInt64LittleEndian(listStart, 0L);
 
             // Reserve space for the length of the list
-            persistentStorage.WriteAll(listStart + sizeof(long), BitConverter.GetBytes(0), 0, sizeof(int));
+            persistentStorage.WriteInt32LittleEndian(listStart + sizeof(long), 0);
         }
 
         public void AddOccurrence(Occurrence occurrence)
@@ -186,16 +187,16 @@ namespace Protsyk.PMS.FullText.Core
 
         public void UpdateNextList(PostingListAddress address, PostingListAddress nextList)
         {
-            var buffer = new byte[sizeof(long)];
-            var offset = address.Offset;
+            Span<byte> buffer = stackalloc byte[8];
+            long offset = address.Offset;
             while (true)
             {
-                persistentStorage.ReadAll(offset, buffer, 0, buffer.Length);
-                long continuationOffset = BitConverter.ToInt64(buffer, 0);
+                persistentStorage.ReadAll(offset, buffer);
+                long continuationOffset = BinaryPrimitives.ReadInt64LittleEndian(buffer);
 
                 if (continuationOffset == 0)
                 {
-                    persistentStorage.WriteAll(offset, BitConverter.GetBytes(nextList.Offset), 0, sizeof(long));
+                    persistentStorage.WriteInt64LittleEndian(offset, nextList.Offset);
                     break;
                 }
                 else

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListPackedIntDeltaWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListPackedIntDeltaWriter.cs
@@ -187,12 +187,10 @@ namespace Protsyk.PMS.FullText.Core
 
         public void UpdateNextList(PostingListAddress address, PostingListAddress nextList)
         {
-            Span<byte> buffer = stackalloc byte[8];
             long offset = address.Offset;
             while (true)
             {
-                persistentStorage.ReadAll(offset, buffer);
-                long continuationOffset = BinaryPrimitives.ReadInt64LittleEndian(buffer);
+                long continuationOffset = persistentStorage.ReadInt64LittleEndian(offset);
 
                 if (continuationOffset == 0)
                 {

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListVarIntDeltaReader.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListVarIntDeltaReader.cs
@@ -111,7 +111,7 @@ namespace Protsyk.PMS.FullText.Core
                         return 0;
                     }
 
-                    persistentStorage.ReadAll(readOffset, buffer, 0, toRead);
+                    persistentStorage.ReadAll(readOffset, buffer.AsSpan(0, toRead));
 
                     for (int i=toRead; i<buffer.Length; ++i)
                     {
@@ -153,7 +153,7 @@ namespace Protsyk.PMS.FullText.Core
                         }
 
                         var header = new byte[HeaderLength];
-                        persistentStorage.ReadAll(readOffset, header, 0, header.Length);
+                        persistentStorage.ReadAll(readOffset, header);
 
                         continuationOffset = BitConverter.ToInt64(header, 0);
                         listEndOffset = readOffset + HeaderLength + BitConverter.ToInt32(header, sizeof(long));
@@ -186,7 +186,7 @@ namespace Protsyk.PMS.FullText.Core
                                 var midOffset = readOffset + buffer.Length * mid;
                                 var inList = (listEndOffset - midOffset - buffer.Length);
                                 var toRead = inList > t.Length ? t.Length : (int)inList;
-                                persistentStorage.ReadAll(midOffset, t, 0, toRead);
+                                persistentStorage.ReadAll(midOffset, t.AsSpan(0, toRead));
 
                                 // Block 1: Full occurrence
                                 var j = 0;

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListVarIntDeltaWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListVarIntDeltaWriter.cs
@@ -150,12 +150,10 @@ namespace Protsyk.PMS.FullText.Core
 
         public void UpdateNextList(PostingListAddress address, PostingListAddress nextList)
         {
-            Span<byte> buffer = stackalloc byte[8];
-            var offset = address.Offset;
+            long offset = address.Offset;
             while (true)
             {
-                persistentStorage.ReadAll(offset, buffer);
-                long continuationOffset = BinaryPrimitives.ReadInt64LittleEndian(buffer);
+                long continuationOffset = persistentStorage.ReadInt64LittleEndian(offset);
 
                 if (continuationOffset == 0)
                 {

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListVarIntDeltaWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/PostingListVarIntDeltaWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.IO;
 using Protsyk.PMS.FullText.Core.Common;
 using Protsyk.PMS.FullText.Core.Common.Persistance;
@@ -65,10 +66,10 @@ namespace Protsyk.PMS.FullText.Core
             listStart = persistentStorage.Length;
 
             // Reserve space for continuation offset
-            persistentStorage.WriteAll(listStart, BitConverter.GetBytes(0L), 0, sizeof(long));
+            persistentStorage.WriteInt64LittleEndian(listStart, 0L);
 
             // Reserve space for the length of the list
-            persistentStorage.WriteAll(listStart + sizeof(long), BitConverter.GetBytes(0), 0, sizeof(int));
+            persistentStorage.WriteInt32LittleEndian(listStart + sizeof(long), 0);
         }
 
         public void AddOccurrence(Occurrence occurrence)
@@ -149,16 +150,16 @@ namespace Protsyk.PMS.FullText.Core
 
         public void UpdateNextList(PostingListAddress address, PostingListAddress nextList)
         {
-            var buffer = new byte[sizeof(long)];
+            Span<byte> buffer = stackalloc byte[8];
             var offset = address.Offset;
             while (true)
             {
-                persistentStorage.ReadAll(offset, buffer, 0, buffer.Length);
-                long continuationOffset = BitConverter.ToInt64(buffer, 0);
+                persistentStorage.ReadAll(offset, buffer);
+                long continuationOffset = BinaryPrimitives.ReadInt64LittleEndian(buffer);
 
                 if (continuationOffset == 0)
                 {
-                    persistentStorage.WriteAll(offset, BitConverter.GetBytes(nextList.Offset), 0, sizeof(long));
+                    persistentStorage.WriteInt64LittleEndian(offset, nextList.Offset);
                     break;
                 }
                 else


### PR DESCRIPTION
This PR continues to focus on reducing allocations and virtual calls.

- Seals various internal classes
- Adds non-allocating helpers to write text, Int32, and Int64 values to persistent storage
- Converts some logic to use switch statements to improve readability
- Use new() when there is a verbose typename defined on the LHS
- Use pattern matching to improve readability