### PR TITLE
Target net8.0

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -17,8 +17,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: | 
-          6.0.x
-          7.0.x
+          8.0.x
     - name: Install dependencies
       run: dotnet restore ./Src/
     - name: Build

--- a/Src/Protsyk.PMS.FullText.ConsoleUtil/Protsyk.PMS.FullText.ConsoleUtil.csproj
+++ b/Src/Protsyk.PMS.FullText.ConsoleUtil/Protsyk.PMS.FullText.ConsoleUtil.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Petro Protsyk</Authors>
     <Product>PMS FullText Search</Product>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Src/Protsyk.PMS.FullText.Core.UnitTests/BtreePersistentTests.cs
+++ b/Src/Protsyk.PMS.FullText.Core.UnitTests/BtreePersistentTests.cs
@@ -59,7 +59,7 @@ public class BtreePersistentTests : TestWithFolderBase
 
     [Theory]
     [InlineData(1000)]
-    public string TestBtreeP(int size)
+    public void TestBtreeP(int size)
     {
         var rnd = Enumerable.Range(1, size).ToArray().Shuffle();
         var testFile = Path.Combine(TestFolder, "btree-test.bin");
@@ -94,7 +94,5 @@ public class BtreePersistentTests : TestWithFolderBase
                 Assert.False(tree.ContainsKey(i));
             }
         }
-
-        return testFile;
     }
 }

--- a/Src/Protsyk.PMS.FullText.Core.UnitTests/Protsyk.PMS.FullText.Core.UnitTests.csproj
+++ b/Src/Protsyk.PMS.FullText.Core.UnitTests/Protsyk.PMS.FullText.Core.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/Protsyk.PMS.FullText.Core/Collections/Btree.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/Btree.cs
@@ -32,10 +32,7 @@ public class Btree<TKey, TValue> : IDictionary<TKey, TValue>
 
     public Btree(int order)
     {
-        if (order < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(order));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(order);
 
         this.order = order;
         this.maxChildren = 2 * order;

--- a/Src/Protsyk.PMS.FullText.Core/Collections/BtreePersistent.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/BtreePersistent.cs
@@ -38,11 +38,7 @@ public class BtreePersistent<TKey, TValue> : IDictionary<TKey, TValue>, IDisposa
     public BtreePersistent(IPersistentStorage persistentStorage, int order)
     {
         ArgumentNullException.ThrowIfNull(persistentStorage);
-
-        if (order < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(order));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(order);
 
         keySerializer = DataSerializer.GetDefault<TKey>();
         valueSerializer = DataSerializer.GetDefault<TValue>();

--- a/Src/Protsyk.PMS.FullText.Core/Collections/HeapExtensions.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/HeapExtensions.cs
@@ -30,11 +30,7 @@ public static class HeapExtensions
     {
         ArgumentNullException.ThrowIfNull(items);
         ArgumentNullException.ThrowIfNull(comparer);
-
-        if (n < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(n));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(n);
 
         if (n == 0)
         {

--- a/Src/Protsyk.PMS.FullText.Core/Collections/LFUCache.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/LFUCache.cs
@@ -9,10 +9,7 @@ public class LFUCache<TKey, TValue>
 
     public LFUCache(int capacity)
     {
-        if (capacity <= 0)
-        {
-            throw new ArgumentOutOfRangeException();
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
 
         this.capacity = capacity;
         this.nextOrder = 0;

--- a/Src/Protsyk.PMS.FullText.Core/Collections/LRUCache.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/LRUCache.cs
@@ -13,10 +13,7 @@ public class LRUCache<TKey, TValue>
 
     public LRUCache(int capacity)
     {
-        if (capacity < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(capacity));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
 
         items = new Dictionary<TKey, LinkedListNode<(TKey, TValue)>>();
         usageQueue = new LinkedList<(TKey, TValue)>();

--- a/Src/Protsyk.PMS.FullText.Core/Collections/PersistentDictionary.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Collections/PersistentDictionary.cs
@@ -42,10 +42,8 @@ public class PersistentDictionary<TValue> : IDisposable
         get
         {
             var offset = linearIndex[index];
-            if (offset == 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+
+            ArgumentOutOfRangeException.ThrowIfZero(offset);
 
             int dataSize = dataStorage.ReadInt32LittleEndian(offset);
 

--- a/Src/Protsyk.PMS.FullText.Core/Common/PackedInts.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/PackedInts.cs
@@ -227,7 +227,7 @@ public class PackedIntN8 : IPackedInts
     private const int BitsInBaseType = 8;
     private const int LastBitIndexInBaseType = 7;
 
-    private static readonly uint[] mask = new uint[] {
+    private static ReadOnlySpan<uint> mask => [
         0b0000_0000,
         0b0000_0001,
         0b0000_0011,
@@ -237,7 +237,7 @@ public class PackedIntN8 : IPackedInts
         0b0011_1111,
         0b0111_1111,
         0b1111_1111
-    };
+    ];
 
     private readonly byte[] data;
     private readonly int bits;
@@ -393,7 +393,7 @@ public class PackedIntN16 : IPackedInts
     private const int BitsInBaseType = 16;
     private const int LastBitIndexInBaseType = 15;
 
-    private static readonly uint[] mask = new uint[] {
+    private static ReadOnlySpan<uint> mask => [
         0b0000_0000_0000_0000,
         0b0000_0000_0000_0001,
         0b0000_0000_0000_0011,
@@ -411,7 +411,7 @@ public class PackedIntN16 : IPackedInts
         0b0011_1111_1111_1111,
         0b0111_1111_1111_1111,
         0b1111_1111_1111_1111 
-    };
+    ];
 
     private readonly ushort[] data;
     private readonly int bits;
@@ -579,7 +579,7 @@ public class PackedIntN32 : IPackedInts
     private const int BitsInBaseType = 32;
     private const int LastBitIndexInBaseType = 31;
 
-    private static readonly uint[] mask = new uint[] {
+    private static ReadOnlySpan<uint> mask => [
         0b0000_0000_0000_0000_0000_0000_0000_0000,
         0b0000_0000_0000_0000_0000_0000_0000_0001,
         0b0000_0000_0000_0000_0000_0000_0000_0011,
@@ -613,7 +613,7 @@ public class PackedIntN32 : IPackedInts
         0b0011_1111_1111_1111_1111_1111_1111_1111,
         0b0111_1111_1111_1111_1111_1111_1111_1111,
         0b1111_1111_1111_1111_1111_1111_1111_1111 
-    };
+    ];
 
     private readonly uint[] data;
     private readonly int bits;
@@ -786,7 +786,7 @@ public class PackedIntN64 : IPackedInts, IPackedLongs
     private const int BitsInBaseType = 64;
     private const int LastBitIndexInBaseType = 63;
 
-    private static readonly ulong[] mask = new ulong[] {
+    private static ReadOnlySpan<ulong> mask => [
         0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000,
         0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0001,
         0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0011,
@@ -852,7 +852,7 @@ public class PackedIntN64 : IPackedInts, IPackedLongs
         0b0011_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111,
         0b0111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111,
         0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111 
-    };
+    ];
 
     private readonly ulong[] data;
     private readonly int bits;

--- a/Src/Protsyk.PMS.FullText.Core/Common/UTF8DfaDecoder.cs
+++ b/Src/Protsyk.PMS.FullText.Core/Common/UTF8DfaDecoder.cs
@@ -11,8 +11,8 @@ public class UTF8DfaDecoder
     //
     // Type 0                   Invalid UTF-8 byte
     // Type 2                   10xxxxxx
-    private static readonly int[] ByteClass = new int[]
-    {
+    private static ReadOnlySpan<int> ByteClass =>
+    [
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -29,16 +29,16 @@ public class UTF8DfaDecoder
         3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
         4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
         5, 5, 5, 5, 5, 5, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0
-    };
+    ];
 
     // State ID = k * 6, where k = 0, 1, 2, 3
     // 6 - number of transitions corresponding to 6 byte types
-    private static readonly int[] states = new int[]{
+    private static ReadOnlySpan<int> states => [
         -1,  0, -1,  6, 12, 18, // state 0
         -1, -1,  0, -1, -1, -1, // state 1 * 6
         -1, -1,  6, -1, -1, -1, // state 2 * 6
         -1, -1, 12, -1, -1, -1, // state 3 * 6
-    };
+    ];
 
     static UTF8DfaDecoder()
     {

--- a/Src/Protsyk.PMS.FullText.Core/IndexModels/TextPosition.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexModels/TextPosition.cs
@@ -8,15 +8,8 @@ public readonly struct TextPosition : IEquatable<TextPosition>, IComparable<Text
    
     public TextPosition(int offset, int length)
     {
-        if (offset < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(offset));
-        }
-        
-        if (length < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(length));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
 
         Offset = offset;
         Length = length;

--- a/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/DeltaVarIntListWriter.cs
+++ b/Src/Protsyk.PMS.FullText.Core/IndexTypes/Persistent/DeltaVarIntListWriter.cs
@@ -65,10 +65,7 @@ public class DeltaVarIntListWriter : IDisposable
 
     public void AddValue(ulong value)
     {
-        if (value == 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(value));
-        }
+        ArgumentOutOfRangeException.ThrowIfZero(value);
 
         if (first)
         {
@@ -78,10 +75,7 @@ public class DeltaVarIntListWriter : IDisposable
         }
         else
         {
-            if (value <= previous)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, previous);
 
             int previousIndex = bufferIndex;
             bufferIndex += VarInt.WriteVUInt64(value - previous, buffer.AsSpan(bufferIndex));

--- a/Src/Protsyk.PMS.FullText.Core/Protsyk.PMS.FullText.Core.csproj
+++ b/Src/Protsyk.PMS.FullText.Core/Protsyk.PMS.FullText.Core.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>11</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Petro Protsyk</Authors>
     <Product>PMS FullText Search</Product>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
This PR:

- Updates the project target to net8.0
- Updates xunit and fixes analyzer errors
- Replaces LCP (longest common prefix) with optimized CommonPrefixLength
- Replaces a few instances of HashSet with optimized SearchValues
- Replaces a few readonly arrays with static data (this now works with primitive types)
- Utilized the new ArgumentOutOfRangeException helpers